### PR TITLE
feat(GenericModel): Add trust_remote_code support

### DIFF
--- a/src/xturing/engines/generic_engine.py
+++ b/src/xturing/engines/generic_engine.py
@@ -9,7 +9,10 @@ class GenericEngine(CausalEngine):
     config_name: str = "generic_engine"
 
     def __init__(
-        self, model_name: str, weights_path: Optional[Union[str, Path]] = None, trust_remote_code: Optional[bool] = False
+        self,
+        model_name: str,
+        weights_path: Optional[Union[str, Path]] = None,
+        trust_remote_code: Optional[bool] = False,
     ):
         super().__init__(
             model_name=model_name,
@@ -28,11 +31,13 @@ class GenericLoraEngine(CausalLoraEngine):
         model_name: str,
         target_modules: List[str],
         weights_path: Optional[Union[str, Path]] = None,
+        trust_remote_code: Optional[bool] = False,
     ):
         super().__init__(
             model_name=model_name,
             weights_path=weights_path,
             target_modules=target_modules,
+            trust_remote_code=trust_remote_code,
         )
 
         self.tokenizer.pad_token = self.tokenizer.eos_token
@@ -41,9 +46,17 @@ class GenericLoraEngine(CausalLoraEngine):
 class GenericInt8Engine(CausalEngine):
     config_name: str = "generic_engine_int8"
 
-    def __init__(self, model_name, weights_path: Optional[Union[str, Path]] = None):
+    def __init__(
+        self,
+        model_name,
+        weights_path: Optional[Union[str, Path]] = None,
+        trust_remote_code: Optional[bool] = False,
+    ):
         super().__init__(
-            model_name=model_name, weights_path=weights_path, load_8bit=True
+            model_name=model_name,
+            weights_path=weights_path,
+            load_8bit=True,
+            trust_remote_code=trust_remote_code,
         )
 
         self.tokenizer.pad_token = self.tokenizer.eos_token
@@ -57,12 +70,14 @@ class GenericLoraInt8Engine(CausalLoraEngine):
         model_name: str,
         target_modules: List[str],
         weights_path: Optional[Union[str, Path]] = None,
+        trust_remote_code: Optional[bool] = False,
     ):
         super().__init__(
             model_name=model_name,
             weights_path=weights_path,
             load_8bit=True,
             target_modules=target_modules,
+            trust_remote_code=trust_remote_code,
         )
 
         self.tokenizer.pad_token = self.tokenizer.eos_token

--- a/src/xturing/models/causal.py
+++ b/src/xturing/models/causal.py
@@ -213,9 +213,15 @@ class CausalInt8Model(CausalModel):
         engine: str,
         weights_path: Optional[str] = None,
         model_name: Optional[str] = None,
+        trust_remote_code: Optional[bool] = False,
     ):
         assert_not_cpu_int8()
-        super().__init__(engine, weights_path=weights_path, model_name=model_name)
+        super().__init__(
+            engine,
+            weights_path=weights_path,
+            model_name=model_name,
+            trust_remote_code=trust_remote_code,
+        )
 
 
 class CausalLoraModel(CausalModel):
@@ -225,12 +231,14 @@ class CausalLoraModel(CausalModel):
         weights_path: Optional[str] = None,
         model_name: Optional[str] = None,
         target_modules: Optional[List[str]] = None,
+        trust_remote_code: Optional[bool] = False,
     ):
         super().__init__(
             engine,
             weights_path=weights_path,
             model_name=model_name,
             target_modules=target_modules,
+            trust_remote_code=trust_remote_code,
         )
 
     def _make_trainer(
@@ -260,6 +268,7 @@ class CausalLoraInt8Model(CausalLoraModel):
         weights_path: Optional[str] = None,
         model_name: Optional[str] = None,
         target_modules: Optional[List[str]] = None,
+        trust_remote_code: Optional[bool] = False,
     ):
         assert_not_cpu_int8()
         super().__init__(
@@ -267,4 +276,5 @@ class CausalLoraInt8Model(CausalLoraModel):
             weights_path=weights_path,
             model_name=model_name,
             target_modules=target_modules,
+            trust_remote_code=trust_remote_code,
         )

--- a/src/xturing/models/generic.py
+++ b/src/xturing/models/generic.py
@@ -17,13 +17,18 @@ from xturing.models.causal import (
 class GenericModel(CausalModel):
     config_name: str = "generic"
 
-    def __init__(self, model_name: str, weights_path: Optional[str] = None, trust_remote_code: Optional[bool] = False):
+    def __init__(
+        self,
+        model_name: str,
+        weights_path: Optional[str] = None,
+        trust_remote_code: Optional[bool] = False,
+    ):
         super().__init__(
-            GenericEngine.config_name, 
-            weights_path, 
-            model_name=model_name, 
-            trust_remote_code=trust_remote_code
-            )
+            GenericEngine.config_name,
+            weights_path,
+            model_name=model_name,
+            trust_remote_code=trust_remote_code,
+        )
 
 
 class GenericLoraModel(CausalLoraModel):
@@ -34,21 +39,31 @@ class GenericLoraModel(CausalLoraModel):
         model_name: str,
         target_modules: List[str] = ["c_attn"],
         weights_path: Optional[str] = None,
+        trust_remote_code: Optional[bool] = False,
     ):
         super().__init__(
             GenericLoraEngine.config_name,
             weights_path,
             model_name=model_name,
             target_modules=target_modules,
+            trust_remote_code=trust_remote_code,
         )
 
 
 class GenericInt8Model(CausalInt8Model):
     config_name: str = "generic_int8"
 
-    def __init__(self, model_name: str, weights_path: Optional[str] = None):
+    def __init__(
+        self,
+        model_name: str,
+        weights_path: Optional[str] = None,
+        trust_remote_code: Optional[bool] = False,
+    ):
         super().__init__(
-            GenericInt8Engine.config_name, weights_path, model_name=model_name
+            GenericInt8Engine.config_name,
+            weights_path,
+            model_name=model_name,
+            trust_remote_code=trust_remote_code,
         )
 
 
@@ -60,10 +75,12 @@ class GenericLoraInt8Model(CausalLoraInt8Model):
         model_name: str,
         target_modules: List[str] = ["c_attn"],
         weights_path: Optional[str] = None,
+        trust_remote_code: Optional[bool] = False,
     ):
         super().__init__(
             GenericLoraInt8Engine.config_name,
             weights_path,
             model_name=model_name,
             target_modules=target_modules,
+            trust_remote_code=trust_remote_code,
         )


### PR DESCRIPTION
This commit introduces the `trust_remote_code` parameter to the `GenericModel` and `GenericEngine` classes. This allows users to specify if they trust the remote code when initializing a `GenericModel`.

The `trust_remote_code` parameter is passed through to the `CausalEngine` class, which uses it when loading the model. This enhancement increases the flexibility of the `GenericModel` class. It now can be used with models that require the execution of remote code.

BREAKING CHANGE: This change should be used with caution. Trusting remote code can have security implications. Always ensure that the source of the model is trusted and the code is understood before enabling this option.